### PR TITLE
chore: Stop publish job from failing when there are no changes in adapter

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,7 +40,9 @@ jobs:
         run: |
           yarn build-angular-adapter
           git add .
-          git commit -m "${{ steps.get_branch_code.outputs.branch_code }}: Generate adapters [skip ci]"
+          if [[ $(git diff --cached --exit-code) ]]; then
+            git commit -m "${{ steps.get_branch_code.outputs.branch_code }}: Generate adapters [skip ci]"
+          fi
 
       - name: Bump package versions
         run: |

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -12,9 +12,7 @@ set -e
 
 # Pop stash if any of the processes fail
 cleanup() {
-  echo Exiting
   git stash pop || true
-
   exit $?
 }
 trap cleanup EXIT ERR
@@ -29,8 +27,5 @@ npx yarn format
 
 # Stage and commit files that have been formatted
 git add .
-
-# Pop stash with uncommited files
-git stash pop
 
 echo "\n--Pre-commit check has passed--\n"


### PR DESCRIPTION
Script was failing when commiting without any changes. Added condition to make it only commit if there are changes.

---

[Branch Storybook](https://nge--$APP_ID.chromatic.com)